### PR TITLE
add redisclusters.redis.redis.opstreelabs.in/role-anti-affinity-topol…

### DIFF
--- a/example/v1beta2/redis-cluster-deploy/role-anti-affinity.yaml
+++ b/example/v1beta2/redis-cluster-deploy/role-anti-affinity.yaml
@@ -11,6 +11,7 @@ metadata:
     # for better high availability
     # PS: you should enable operator webhook for this to work
     redisclusters.redis.redis.opstreelabs.in/role-anti-affinity: "true"
+    redisclusters.redis.redis.opstreelabs.in/role-anti-affinity-topology-key: "kubernetes.io/hostname"
 spec:
   clusterSize: 3
   clusterVersion: v7


### PR DESCRIPTION
…ogy-key

<!--
    Please read https://github.com/OT-CONTAINER-KIT/redis-operator/blob/main/CONTRIBUTING.md before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #ISSUE

**Type of change**

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)
* Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Checklist**

- [ ] Tests have been added/modified and all tests pass.
- [ ] Functionality/bugs have been confirmed to be unchanged or fixed.
- [ ] I have performed a self-review of my own code.
- [ ] Documentation has been updated or added where necessary.

**Additional Context**

<!--
    Is there anything else you'd like reviewers to know?
    For example, any other related issues or testing carried out.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for specifying a custom topology key for RedisCluster pod anti-affinity using an annotation. This allows leader and follower pods to be spread across different nodes based on the provided topology key, improving pod distribution and resilience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->